### PR TITLE
removing entrypoint from comet

### DIFF
--- a/Comet/2015011/Dockerfile
+++ b/Comet/2015011/Dockerfile
@@ -18,7 +18,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ################## BEGIN INSTALLATION ######################
 
-USER root
+USER biodocker
 
 RUN ZIP=comet_binaries_2015011.zip && \
     wget https://github.com/BioDocker/software-archive/releases/download/Comet/$ZIP -O /tmp/$ZIP && \
@@ -29,8 +29,6 @@ RUN ZIP=comet_binaries_2015011.zip && \
 RUN mv /home/biodocker/bin/Comet/comet.2015011.linux.exe /home/biodocker/bin/Comet/comet
 
 ENV PATH /home/biodocker/bin/Comet:$PATH
-
-USER biodocker
 
 WORKDIR /data
 

--- a/Comet/2015011/Dockerfile
+++ b/Comet/2015011/Dockerfile
@@ -36,4 +36,4 @@ WORKDIR /data
 
 # File Author / Maintainer
 MAINTAINER Felipe da Veiga Leprevost <felipe@leprevost.com.br>
-# Modified by Felipe da Veiga Leprevost 08-27-2015
+# Modified by Felipe da Veiga Leprevost 11-27-2015

--- a/Comet/2015011/Dockerfile
+++ b/Comet/2015011/Dockerfile
@@ -26,13 +26,13 @@ RUN ZIP=comet_binaries_2015011.zip && \
     chmod -R 755 /home/biodocker/bin/Comet/* && \
     rm /tmp/$ZIP
 
+RUN mv /home/biodocker/bin/Comet/comet.2015011.linux.exe /home/biodocker/bin/Comet/comet
+
 ENV PATH /home/biodocker/bin/Comet:$PATH
 
 USER biodocker
 
 WORKDIR /data
-
-ENTRYPOINT ["/home/biodocker/bin/Comet/comet.2015011.linux.exe"]
 
 ##################### INSTALLATION END #####################
 

--- a/Comet/2015012/Dockerfile
+++ b/Comet/2015012/Dockerfile
@@ -26,13 +26,13 @@ RUN ZIP=comet_binaries_2015012.zip && \
     chmod -R 755 /home/biodocker/bin/Comet/* && \
     rm /tmp/$ZIP
 
+RUN mv /home/biodocker/bin/Comet/comet.2015012.linux.exe /home/biodocker/bin/Comet/comet
+
 ENV PATH /home/biodocker/bin/Comet:$PATH
 
 USER biodocker
 
 WORKDIR /data
-
-ENTRYPOINT ["/home/biodocker/bin/Comet/comet.2015012.linux.exe"]
 
 ##################### INSTALLATION END #####################
 

--- a/Comet/2015012/Dockerfile
+++ b/Comet/2015012/Dockerfile
@@ -36,4 +36,4 @@ WORKDIR /data
 
 # File Author / Maintainer
 MAINTAINER Felipe da Veiga Leprevost <felipe@leprevost.com.br>
-# Modified by Felipe da Veiga Leprevost 08-27-2015
+# Modified by Felipe da Veiga Leprevost 11-27-2015

--- a/Comet/2015012/Dockerfile
+++ b/Comet/2015012/Dockerfile
@@ -18,7 +18,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ################## BEGIN INSTALLATION ######################
 
-USER root
+USER biodocker
 
 RUN ZIP=comet_binaries_2015012.zip && \
     wget https://github.com/BioDocker/software-archive/releases/download/Comet/$ZIP -O /tmp/$ZIP && \
@@ -29,8 +29,6 @@ RUN ZIP=comet_binaries_2015012.zip && \
 RUN mv /home/biodocker/bin/Comet/comet.2015012.linux.exe /home/biodocker/bin/Comet/comet
 
 ENV PATH /home/biodocker/bin/Comet:$PATH
-
-USER biodocker
 
 WORKDIR /data
 

--- a/Comet/2015020/Dockerfile
+++ b/Comet/2015020/Dockerfile
@@ -19,7 +19,7 @@ FROM biodckr/biodocker:latest
 
 ################## BEGIN INSTALLATION ######################
 
-USER root
+USER biodocker
 
 RUN ZIP=comet_binaries_2015020.zip && \
     wget https://github.com/BioDocker/software-archive/releases/download/Comet/$ZIP -O /tmp/$ZIP && \
@@ -30,8 +30,6 @@ RUN ZIP=comet_binaries_2015020.zip && \
 RUN mv /home/biodocker/bin/Comet/comet.2015020.linux.exe /home/biodocker/bin/Comet/comet
 
 ENV PATH /home/biodocker/bin/Comet:$PATH
-
-USER biodocker
 
 WORKDIR /data
 

--- a/Comet/2015020/Dockerfile
+++ b/Comet/2015020/Dockerfile
@@ -37,4 +37,4 @@ WORKDIR /data
 
 # File Author / Maintainer
 MAINTAINER Felipe da Veiga Leprevost <felipe@leprevost.com.br>
-# Modified by Felipe da Veiga Leprevost 08-27-2015
+# Modified by Felipe da Veiga Leprevost 11-27-2015

--- a/Comet/2015020/Dockerfile
+++ b/Comet/2015020/Dockerfile
@@ -27,13 +27,13 @@ RUN ZIP=comet_binaries_2015020.zip && \
     chmod -R 755 /home/biodocker/bin/Comet/* && \
     rm /tmp/$ZIP
 
+RUN mv /home/biodocker/bin/Comet/comet.2015020.linux.exe /home/biodocker/bin/Comet/comet
+
 ENV PATH /home/biodocker/bin/Comet:$PATH
 
 USER biodocker
 
 WORKDIR /data
-
-ENTRYPOINT ["/home/biodocker/bin/Comet/comet.2015020.linux.exe"]
 
 ##################### INSTALLATION END #####################
 

--- a/Comet/2015020/Dockerfile
+++ b/Comet/2015020/Dockerfile
@@ -11,7 +11,7 @@
 # Base Image:       biodckr/biodocker:latest
 # Build Cmd:        docker build --rm -t biodckr/comet 2015020/.
 # Pull Cmd:         docker pull biodckr/comet
-# Run Cmd:          docker run --rm biodckr/comet
+# Run Cmd:          docker run --rm biodckr/comet comet
 #################################################################
 
 # Set the base image to biodckr/biodocker

--- a/PeptideProphet/201510131012/Dockerfile
+++ b/PeptideProphet/201510131012/Dockerfile
@@ -7,7 +7,7 @@
 # Base Image:       biodckr/biodocker:latest
 # Build Cmd:        docker build -t biodckr/PeptideProphet 201510131012/.
 # Pull Cmd:         docker pull biodckr/PeptideProphet
-# Run Cmd:          docker run biodckr/PeptideProphet
+# Run Cmd:          docker run biodckr/PeptideProphet PeptideProphet
 #################################################################
 
 # Set the base image to biodckr/biodocker
@@ -18,7 +18,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ################## BEGIN INSTALLATION ######################
 
-USER root
+USER biodocker
 
 RUN ZIP=PeptideProphetParser.zip && \
     wget https://github.com/BioDocker/software-archive/releases/download/PeptideProphet/$ZIP -O /tmp/$ZIP && \
@@ -30,12 +30,10 @@ RUN mv /home/biodocker/bin/PeptideProphetParser /home/biodocker/bin/PeptideProph
 
 ENV PATH /home/biodocker/bin:$PATH
 
-USER biodocker
-
 WORKDIR /data
 
 ##################### INSTALLATION END #####################
 
 # File Author / Maintainer
 MAINTAINER Felipe da Veiga Leprevost <felipe@leprevost.com.br>
-# Modified by Felipe da Veiga Leprevost 08-27-2015
+# Modified by Felipe da Veiga Leprevost 11-27-2015

--- a/ProteinProphet/201510131012/Dockerfile
+++ b/ProteinProphet/201510131012/Dockerfile
@@ -18,6 +18,24 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ################## BEGIN INSTALLATION ######################
 
+USER root 
+
+RUN apt-get update && \
+    apt-get install -y gnuplot
+
+
+RUN sudo mkdir -p /usr/local/tpp/bin/
+
+RUN ZIP=DatabaseParser.zip && \
+    wget https://github.com/BioDocker/software-archive/releases/download/DatabaseParser/$ZIP -O /tmp/$ZIP && \
+    unzip /tmp/$ZIP -d /usr/local/tpp/bin/ && \
+    rm /tmp/$ZIP
+
+RUN ZIP=batchcoverage.zip && \
+    wget https://github.com/BioDocker/software-archive/releases/download/BatchCoverage/$ZIP -O /tmp/$ZIP && \
+    unzip /tmp/$ZIP -d /usr/local/tpp/bin/ && \
+    rm /tmp/$ZIP
+
 USER biodocker
 
 RUN ZIP=ProteinProphet.zip && \
@@ -28,7 +46,7 @@ RUN ZIP=ProteinProphet.zip && \
 
 ENV PATH /home/biodocker/bin:$PATH
 
-WORKDIR /data
+WORKDIR /data/
 
 ##################### INSTALLATION END #####################
 

--- a/ProteinProphet/201510131012/Dockerfile
+++ b/ProteinProphet/201510131012/Dockerfile
@@ -7,7 +7,7 @@
 # Base Image:       biodckr/biodocker:latest
 # Build Cmd:        docker build -t biodckr/ProteinProphet 201510131012/.
 # Pull Cmd:         docker pull biodckr/ProteinProphet
-# Run Cmd:          docker run biodckr/ProteinProphet
+# Run Cmd:          docker run biodckr/ProteinProphet ProteinProphet
 #################################################################
 
 # Set the base image to biodckr/biodocker
@@ -18,7 +18,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ################## BEGIN INSTALLATION ######################
 
-USER root
+USER biodocker
 
 RUN ZIP=ProteinProphet.zip && \
     wget https://github.com/BioDocker/software-archive/releases/download/ProteinProphet/$ZIP -O /tmp/$ZIP && \
@@ -28,12 +28,10 @@ RUN ZIP=ProteinProphet.zip && \
 
 ENV PATH /home/biodocker/bin:$PATH
 
-USER biodocker
-
 WORKDIR /data
 
 ##################### INSTALLATION END #####################
 
 # File Author / Maintainer
 MAINTAINER Felipe da Veiga Leprevost <felipe@leprevost.com.br>
-# Modified by Felipe da Veiga Leprevost 08-27-2015
+# Modified by Felipe da Veiga Leprevost 11-27-2015

--- a/TPP/4.8/Dockerfile
+++ b/TPP/4.8/Dockerfile
@@ -20,18 +20,11 @@ FROM biodckr/biodocker:latest
 
 ################## BEGIN INSTALLATION ######################
 
-RUN ZIP=tpp-4.8.0.zip && \
-    wget https://github.com/BioDocker/software-archive/releases/download/TPP/$ZIP -O /tmp/$ZIP && \
-    unzip /tmp/$ZIP -d /home/biodocker/bin/ && \
-    rm /tmp/$ZIP && \
-    ln -vs /home/biodocker/bin/tpp/bin/* /home/biodocker/bin/    
+RUN wget https://github.com/BioDocker/software-archive/releases/download/TPP/tpp-bin-4.8.0.zip
 
-#    bash -c 'echo -e "#!/bin/bash\n/home/biodocker/bin/tpp_src/" > /home/biodocker/bin/tpp' && \
-#    chmod +x /home/biodocker/bin/tpp
+RUN unzip tpp-bin-4.8.0.zip
 
-WORKDIR /data
-
-CMD ["tandem"]
+WORKDIR /tpp-bin-4.8.0/
 
 ##################### INSTALLATION END #####################
 


### PR DESCRIPTION
entrypoint directive complaints if the program is executed with parameters

exec: "-p": executable file not found in $PATH
Error response from daemon: Cannot start container 44303d2fc534577941fb4f29f33ebf5c030ae6fd18c27646c709cde043ab110c: [8] System error: exec: "-p": executable file not found in $PATH

so i removed the entrypoint and added the 'comet' program to the path
