### PR TITLE
Fix GBrowse about url

### DIFF
--- a/gbrowse/2.56dfsg-2-deb/Dockerfile
+++ b/gbrowse/2.56dfsg-2-deb/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER biocontainers <biodocker@gmail.com>
 LABEL    software="gbrowse" \ 
     container="gbrowse" \ 
     about.summary="GMOD Generic Genome Browser" \ 
-    about.home="http://www.gbrowse.org/" \ 
+    about.home="http://gmod.org/wiki/GBrowse" \ 
     software.version="2.56dfsg-2-deb" \ 
     version="1" \ 
     extra.identifiers.biotools="gbrowse" \ 


### PR DESCRIPTION
The GBrowse url used (gbrowse.org) isn't associated with GBrowse, and is defunct anyway.  A better url is for the gmod.org wiki page for GBrowse