### PR TITLE
Added container for new version of bedtools (2.27.0)

### DIFF
--- a/bedtools/2.27.0/Dockerfile
+++ b/bedtools/2.27.0/Dockerfile
@@ -1,0 +1,26 @@
+################## BASE IMAGE ######################
+
+FROM biocontainers/biocontainers:latest
+
+################## METADATA ######################
+
+LABEL base_image="biocontainers:latest"
+LABEL version="2"
+LABEL software="bedtools"
+LABEL software.version="2.27.0"
+LABEL about.summary="a powerful toolset for genome arithmetic"
+LABEL about.home="http://bedtools.readthedocs.io/en/latest/"
+LABEL about.documentation="http://quinlanlab.org/tutorials/bedtools/bedtools.html"
+LABEL about.license_file="https://github.com/arq5x/bedtools2/blob/master/LICENSE"
+LABEL about.license="SPDX:LGPL-2.0-only"
+LABEL extra.identifiers.biotools="bedtools"
+LABEL about.tags="Genomics"
+
+################## MAINTAINER ######################
+MAINTAINER David Mas-Ponte <david.mas.p+gh@gmail.com>
+
+RUN conda install bedtools=2.27.0
+
+WORKDIR /data/
+
+CMD ["bedtools"]


### PR DESCRIPTION
So according with the [change-log](https://bedtools.readthedocs.io/en/latest/content/history.html) in the bedtools website there are major improvements in this version. It is also now available at bioconda (see [here](https://bioconda.github.io/recipes/bedtools/README.html)) so I thought it was pretty straightforward to update the container. Tested that the docker image builds in my computer.

I kept the the info from the container with version 2.25, just changed the version and the maintainer name. 

First pull request so just tell me if I did something wrong. 

( coming from here https://github.com/BioContainers/containers/issues/266 )

 # Submitting a Container
 
 (If you're requesting for a new container, please check the procedure described [here](https://github.com/BioContainers/containers#241-how-to-request-a-container).  
 
 ## Check BioContainers' Dockerfile [specifications](https://github.com/BioContainers/specs)  
 ## Checklist
 
 1. Misc
 - [ ] My tool doesn't exist in [BioConda](#make-sure-your-tool-isnt-already-present-in-bioconda)   
 - [x] The image can be built   
 
 2. [Metadata](#check-biocontainers-dockerfile-metadata)  
 - [x] LABEL base_image  
 - [x] LABEL version
 - [x] LABEL software.version  
 - [x] LABEL about.summary  
 - [x] LABEL about.home  
 - [x] LABEL about.license   
 - [x] MAINTAINER  
 
 3. Extra (optionals)
  - [ ] I have written tests in test-cmds.txt  
  - [x] LABEL extra.identifier    
  - [ ] LABEL about.documentation   
  - [ ] LABEL about.license_file
  - [x] LABEL about.tags   
 
 
 ## Check [BioContainers'](https://github.com/BioContainers/specs) Dockerfile metadata  
