### PR TITLE
add container for cpat

### DIFF
--- a/cpat/1.2.4/Dockerfile
+++ b/cpat/1.2.4/Dockerfile
@@ -3,7 +3,7 @@ FROM biocontainers/biocontainers:v1.0.0_cv4
 
 ################## METADATA ######################
 LABEL base_image="biocontainers:v1.0.0_cv4"
-LABEL version="3"
+LABEL version="1"
 LABEL software="CPAT"
 LABEL software.version="1.2.4"
 LABEL about.summary="Coding Potential Assessment Tool"

--- a/cpat/1.2.4/Dockerfile
+++ b/cpat/1.2.4/Dockerfile
@@ -1,0 +1,26 @@
+################## BASE IMAGE ######################
+FROM biocontainers/biocontainers:v1.0.0_cv4
+
+################## METADATA ######################
+LABEL base_image="biocontainers:v1.0.0_cv4"
+LABEL version="3"
+LABEL software="CPAT"
+LABEL software.version="1.2.4"
+LABEL about.summary="Coding Potential Assessment Tool"
+LABEL about.home="http://rna-cpat.sourceforge.net/"
+LABEL about.documentation="http://rna-cpat.sourceforge.net/"
+LABEL about.license_file="http://rna-cpat.sourceforge.net/#license"
+LABEL about.license="SPDX:GPL-2.0+"
+LABEL extra.identifiers.biotools="cpat"
+LABEL about.tags="field::biology, field::biology:bioinformatics, rna"
+
+################## MAINTAINER ######################
+MAINTAINER Sequencing Analysis Support Core, Leiden University Medical Center <sasc@lumc.nl>
+
+################## INSTALLATION ######################
+
+RUN conda install cpat=1.2.4
+
+WORKDIR /data/
+
+CMD ["cpat.py"]

--- a/cpat/1.2.4/Dockerfile
+++ b/cpat/1.2.4/Dockerfile
@@ -4,7 +4,7 @@ FROM biocontainers/biocontainers:v1.0.0_cv4
 ################## METADATA ######################
 LABEL base_image="biocontainers:v1.0.0_cv4"
 LABEL version="1"
-LABEL software="CPAT"
+LABEL software="cpat"
 LABEL software.version="1.2.4"
 LABEL about.summary="Coding Potential Assessment Tool"
 LABEL about.home="http://rna-cpat.sourceforge.net/"


### PR DESCRIPTION
The regular automatically bioconda based created container does not work as CPATs internal R stuff depends on some system libraries (GNU libreadline.so). This library is not present in the conda-forge, defaults or bioconda channel. Therefore this dependency issue can not be solved with conda.

Therefore this container is based on the biocontainers container (which is based on ubuntu). I tested this container in a small test workflow and it worked. 

EDIT: quay.io/biocontainers/cpat -> These do not work!

 # Submitting a Container
 
 (If you're requesting for a new container, please check the procedure described [here](https://github.com/BioContainers/containers#241-how-to-request-a-container).  
 
 ## Check BioContainers' Dockerfile [specifications](https://github.com/BioContainers/specs)  
 ## Checklist
 
 1. Misc
 - [ ] My tool doesn't exist in [BioConda](#make-sure-your-tool-isnt-already-present-in-bioconda)   
 - [x] The image can be built   
 
 2. [Metadata](#check-biocontainers-dockerfile-metadata)  
 - [x] LABEL base_image  
 - [x] LABEL version
 - [x] LABEL software.version  
 - [x] LABEL about.summary  
 - [x] LABEL about.home  
 - [x] LABEL about.license   
 - [x] MAINTAINER  
 
 3. Extra (optionals)
  - [ ] ~I have written tests in test-cmds.txt~ Already tested in the conda package.
  - [x] LABEL extra.identifier    
  - [x] LABEL about.documentation   
  - [x] LABEL about.license_file
  - [x] LABEL about.tags   
 
 
 ## Check [BioContainers'](https://github.com/BioContainers/specs) Dockerfile metadata  
