### PR TITLE
add container for  Bwakit 

### DIFF
--- a/bwakit/0.7.15/Dockerfile
+++ b/bwakit/0.7.15/Dockerfile
@@ -1,0 +1,38 @@
+################## BASE IMAGE ######################
+FROM biocontainers/biocontainers:v1.0.0_cv4
+
+################## METADATA ######################
+LABEL base_image="biocontainers:v1.0.0_cv4"
+LABEL version="1"
+LABEL software="bwakit"
+LABEL software.version="0.7.15"
+LABEL about.summary="A self-consistent installation-free package of scripts and precompiled binaries, providing an end-to-end solution to read mapping"
+LABEL about.home="http://bio-bwa.sourceforge.net/"
+LABEL about.documentation="http://bio-bwa.sourceforge.net/"
+LABEL about.license_file="http://bio-bwa.sourceforge.net/"
+LABEL about.license="SPDX:GPL-3.0"
+LABEL about.tags="Genomics"
+
+################## MAINTAINER ######################
+MAINTAINER SASC <sasc@lumc.nl>
+
+################## INSTALLATION ######################
+
+RUN conda install bwakit=0.7.15 && \
+    ln -s /opt/conda/share/bwakit-0.7.15-1/bwa /opt/conda/bin/bwa && \
+    ln -s /opt/conda/share/bwakit-0.7.15-1/fermi2 /opt/conda/bin/fermi2 && \
+    ln -s /opt/conda/share/bwakit-0.7.15-1/htsbox /opt/conda/bin/htsbox && \
+    ln -s /opt/conda/share/bwakit-0.7.15-1/k8 /opt/conda/bin/k8 && \
+    ln -s /opt/conda/share/bwakit-0.7.15-1/ropebwt2 /opt/conda/bin/ropebwt2 && \
+    ln -s /opt/conda/share/bwakit-0.7.15-1/samblaster /opt/conda/bin/samblaster && \
+    ln -s /opt/conda/share/bwakit-0.7.15-1/samtools /opt/conda/bin/samtools && \
+    ln -s /opt/conda/share/bwakit-0.7.15-1/seqtk /opt/conda/bin/seqtk && \
+    ln -s /opt/conda/share/bwakit-0.7.15-1/trimadap /opt/conda/bin/trimadap && \
+    ln -s /opt/conda/share/bwakit-0.7.15-1/run-gen-ref /opt/conda/bin/run-gen-ref && \
+    ln -s /opt/conda/share/bwakit-0.7.15-1/typeHLA-selctg.js /opt/conda/bin/typeHLA-selctg.js && \
+    ln -s /opt/conda/share/bwakit-0.7.15-1/typeHLA.js /opt/conda/bin/typeHLA.js && \
+    ln -s /opt/conda/share/bwakit-0.7.15-1/typeHLA.sh /opt/conda/bin/typeHLA.sh && \
+    ln -s /opt/conda/share/bwakit-0.7.15-1/bwa-postalt.js /opt/conda/bin/bwa-postalt.js && \
+    ln -s /opt/conda/share/bwakit-0.7.15-1/fermi2.pl /opt/conda/bin/fermi2.pl
+
+WORKDIR /data/


### PR DESCRIPTION
Bwakit requires a number of dependencies which come packaged with it. The conda recipe does extract them, but doesn't place them in PATH. As such the autogenerated biocontainer doesn't actually work. Since some of the dependencies have their own conda recipes as well, I suspect there would be some hairy side-effect to adjusting the recipe to place them in PATH, hence why I opted to make a seperate Docker image instead.

 # Submitting a Container
 
 (If you're requesting for a new container, please check the procedure described [here](https://github.com/BioContainers/containers#241-how-to-request-a-container).  
 
 ## Check BioContainers' Dockerfile [specifications](https://github.com/BioContainers/specs)  
 ## Checklist
 
 1. Misc
 - [ ] My tool doesn't exist in [BioConda](#make-sure-your-tool-isnt-already-present-in-bioconda)   
 - [x] The image can be built   
 
 2. [Metadata](#check-biocontainers-dockerfile-metadata)  
 - [x] LABEL base_image  
 - [x] LABEL version
 - [x] LABEL software.version  
 - [x] LABEL about.summary  
 - [x] LABEL about.home  
 - [x] LABEL about.license   
 - [x] MAINTAINER  
 
 3. Extra (optionals)
  - [ ] I have written tests in test-cmds.txt  
  - [ ] LABEL extra.identifier    
  - [ ] LABEL about.documentation   
  - [ ] LABEL about.license_file
  - [ ] LABEL about.tags   
 
 
 ## Check [BioContainers'](https://github.com/BioContainers/specs) Dockerfile metadata  
