### PR TITLE
remove the tar archive to hopefully save some space

### DIFF
--- a/ilastik/1.4.0/Dockerfile
+++ b/ilastik/1.4.0/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04 
 
 LABEL base_image="ubuntu:22.04"
-LABEL version="1"
+LABEL version="2"
 LABEL software="ilastik"
 LABEL software.version="1.4.0"
 LABEL about.summary="the interactive learning and segmentation toolkit"
@@ -45,7 +45,8 @@ RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
 
 WORKDIR /opt/
 RUN wget https://files.ilastik.org/ilastik-1.4.0-Linux.tar.bz2 && \
-    tar xjf ilastik-1.*-Linux.tar.bz2
+    tar xjf ilastik-1.*-Linux.tar.bz2 && \
+    rm -f ilastik-1.*-Linux.tar.bz2
 
 
 #ENTRYPOINT["run_ilastik.sh"]


### PR DESCRIPTION
i noticed that the tar file is still present in the ilastik docker containers. Removing it should save 800mb...

 # Submitting a Container
 
 (If you're requesting for a new container, please check the procedure described [here](https://github.com/BioContainers/containers#241-how-to-request-a-container).  
 
 ## Check BioContainers' Dockerfile [specifications](https://github.com/BioContainers/specs)  
 ## Checklist
 
 1. Misc
 - [ ] My tool doesn't exist in [BioConda](#make-sure-your-tool-isnt-already-present-in-bioconda)   
 - [ ] The image can be built   
 
 2. [Metadata](#check-biocontainers-dockerfile-metadata)  
 - [ ] LABEL base_image  
 - [ ] LABEL version
 - [ ] LABEL software.version  
 - [ ] LABEL about.summary  
 - [ ] LABEL about.home  
 - [ ] LABEL about.license   
 - [ ] MAINTAINER  
 
 3. Extra (optionals)
  - [ ] I have written tests in test-cmds.txt  
  - [ ] LABEL extra.identifier    
  - [ ] LABEL about.documentation   
  - [ ] LABEL about.license_file
  - [ ] LABEL about.tags   
 
 
 ## Check [BioContainers'](https://github.com/BioContainers/specs) Dockerfile metadata  


cc @sunyi000 