### PR TITLE
Added procps  to cellpose container

### DIFF
--- a/cellpose/2.1.1/Dockerfile
+++ b/cellpose/2.1.1/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8-slim
 
 LABEL base_image="python:3.8-slim"
-LABEL version="1"
+LABEL version="2"
 LABEL software="cellpose"
 LABEL software.version="2.1.1"
 LABEL about.summary="A generalist algorithm for cell and nucleus segmentation."
@@ -38,6 +38,7 @@ RUN apt-get update -qq && \
             ca-certificates \
             curl \
             locales \
+            procps \
             unzip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* 


### PR DESCRIPTION
This PR adds procps to the docker container. The procps package is required for creating reports in nextflow and using [nf-tower](https://tower.nf/). 

The Cellpose nf-core module requires this addition to fully work in nextflow pipelines: https://github.com/nf-core/modules/blob/master/modules/nf-core/cellpose/main.nf

 # Submitting a Container
 
 (If you're requesting for a new container, please check the procedure described [here](https://github.com/BioContainers/containers#241-how-to-request-a-container).  
 
 ## Check BioContainers' Dockerfile [specifications](https://github.com/BioContainers/specs)  
 ## Checklist
 
 1. Misc
 - [ ] My tool doesn't exist in [BioConda](#make-sure-your-tool-isnt-already-present-in-bioconda)   
 - [ ] The image can be built   
 
 2. [Metadata](#check-biocontainers-dockerfile-metadata)  
 - [ ] LABEL base_image  
 - [ ] LABEL version
 - [ ] LABEL software.version  
 - [ ] LABEL about.summary  
 - [ ] LABEL about.home  
 - [ ] LABEL about.license   
 - [ ] MAINTAINER  
 
 3. Extra (optionals)
  - [ ] I have written tests in test-cmds.txt  
  - [ ] LABEL extra.identifier    
  - [ ] LABEL about.documentation   
  - [ ] LABEL about.license_file
  - [ ] LABEL about.tags   
 
 
 ## Check [BioContainers'](https://github.com/BioContainers/specs) Dockerfile metadata  
