### PR TITLE
Change base image from -slim to normal

### DIFF
--- a/cellpose/2.1.1/Dockerfile
+++ b/cellpose/2.1.1/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.8-slim
+FROM python:3.8
 
 LABEL base_image="python:3.8-slim"
-LABEL version="1"
+LABEL version="2"
 LABEL software="cellpose"
 LABEL software.version="2.1.1"
 LABEL about.summary="A generalist algorithm for cell and nucleus segmentation."

--- a/cellpose/2.1.1/Dockerfile
+++ b/cellpose/2.1.1/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8
 
-LABEL base_image="python:3.8-slim"
+LABEL base_image="python:3.8"
 LABEL version="2"
 LABEL software="cellpose"
 LABEL software.version="2.1.1"


### PR DESCRIPTION
In response to #511, I have modified the base image from `python:3.8-slim` to `python:3.8`.  This does not increase the image size drastically, but provides the functionality to use procps in pipelining tools like nextflow.