### PR TITLE
Incorrect path in README

### DIFF
--- a/cadd-scripts-with-envs/1.6.post1/README.md
+++ b/cadd-scripts-with-envs/1.6.post1/README.md
@@ -17,10 +17,10 @@ Then use the following options
 
 Singularity/Apptainer:
 
-    -B $REFPATH:/opt/conda/share/cadd-scripts-1.6-1/data/annotations
+    -B $REFPATH:/opt/CADD-scripts-1.6.post1/data/annotations
 
 Docker:
 
-    -v $REFPATH:/opt/conda/share/cadd-scripts-1.6-1/data/annotations
+    -v $REFPATH:/opt/CADD-scripts-1.6.post1/data/annotations
 
 


### PR DESCRIPTION
I forgot to update the path in the README, showing where to mount the annotation data. I'm sorry about this, I hope it's not a lot of extra work for you.